### PR TITLE
Kh.make implementation pollute namespace less

### DIFF
--- a/spec/send_spec.cr
+++ b/spec/send_spec.cr
@@ -154,9 +154,9 @@ describe Send do
   end
 
   it "can use annotations to specify whether to use a proc or a record callsite" do
-    TestObj::Send_exponent_Int32__Int32.is_a?(Proc).should be_false
-    TestObj::Send_exponent_Int32__Int32.is_a?(Class).should be_true
-    OtherTestObj::Send_multimultiply_Int16_Int32_String__Int16_Int32_String.is_a?(Proc).should be_true
+    TestObj::Xtn::Send_exponent_Int32__Int32.is_a?(Proc).should be_false
+    TestObj::Xtn::Send_exponent_Int32__Int32.is_a?(Class).should be_true
+    OtherTestObj::Xtn::Send_multimultiply_Int16_Int32_String__Int16_Int32_String.is_a?(Proc).should be_true
   end
 
   # Named parameter support is unavoidably flakey in the current implementation.


### PR DESCRIPTION
This branch just has some cleanup in the constant use, and moves constants into an XTN namespace under whatever class it is included into.