### PR TITLE
Swap NamedTuples for Hashes.

### DIFF
--- a/src/send.cr
+++ b/src/send.cr
@@ -23,27 +23,27 @@ module Send
   macro build_type_lookup_table
     # Constant lookup table for our punctuation conversions.
     Xtn::SendMethodPunctuationLookups = {
-      /\s*\<\s*/ => "LXESXS",
-      /\s*\=\s*/ => "EXQUALXS",
-      /\s*\!\s*/ => "EXXCLAMATIOXN",
-      /\s*\~\s*/ => "TXILDXE",
-      /\s*\>\s*/ => "GXREATEXR",
-      /\s*\+\s*/ => "PXLUXS",
-      /\s*\-\s*/ => "MXINUXS",
-      /\s*\*\s*/ => "AXSTERISXK",
-      /\s*\/\s*/ => "SXLASXH",
-      /\s*\%\s*/ => "PXERCENXT",
-      /\s*\&\s*/ => "AXMPERSANXD",
-      /\s*\?\s*/ => "QXUESTIOXN",
-      /\s*\[\s*/ => "LXBRACKEXT",
-      /\s*\]\s*/ => "RXBRACKEXT"
+      "LXESXS": /\s*\<\s*/,
+      "EXQUALXS": /\s*\=\s*/,
+      "EXXCLAMATIOXN": /\s*\!\s*/,
+      "TXILDXE": /\s*\~\s*/,
+      "GXREATEXR": /\s*\>\s*/,
+      "PXLUXS": /\s*\+\s*/,
+      "MXINUXS": /\s*\-\s*/,
+      "AXSTERISXK": /\s*\*\s*/,
+      "SXLASXH": /\s*\/\s*/,
+      "PXERCENXT": /\s*\%\s*/,
+      "AXMPERSANXD": /\s*\&\s*/,
+      "QXUESTIOXN": /\s*\?\s*/,
+      "LXBRACKEXT": /\s*\[\s*/,
+      "RXBRACKEXT": /\s*\]\s*/,
     }
 
     # This lookup table stores an association of method call signature to method type union, encoded.
     Xtn::SendTypeLookupByLabel = {
-    {% for method in @type.methods %}
-      {{method.args.symbolize}} => {{
-                                     method.args.reject do |arg|
+    {% for args in @type.methods.map(&.args).uniq %}
+      {{args.stringify}}: {{
+                                     args.reject do |arg|
                                        arg.restriction.is_a?(Nop)
                                      end.map do |arg|
                                        arg.restriction.resolve.union? ? arg.restriction.resolve.union_types.map do |ut|
@@ -126,8 +126,8 @@ module Send
                 "use_procs" => use_procs,
               }
               method_name = method.name
-              Xtn::SendMethodPunctuationLookups.each do |punct, name|
-                method_name = method_name.gsub(punct, name)
+              Xtn::SendMethodPunctuationLookups.each do |name, punct|
+                method_name = method_name.gsub(punct, name.stringify)
               end
               src[constant_name][method.name.stringify] = "Xtn::Send_#{method_name}_#{restriction.gsub(/::/, "CXOLOXN").id}"
             end
@@ -135,8 +135,8 @@ module Send
         end
       end
     %}
-    Xtn::SendRawCombos = {{src.stringify.id}}
-    Xtn::SendParameters = {{sends.stringify.id}}
+    Xtn::SendRawCombos = {{src.stringify.gsub(/\s*=>/,":").id}}
+    Xtn::SendParameters = {{sends.stringify.gsub(/\s*=>/,":").id}}
   end
 
   macro build_lookup_constants
@@ -144,7 +144,7 @@ module Send
     {% for constant_name in combo_keys %}
     {% hsh = Xtn::SendRawCombos[constant_name] %}
     {{ constant_name.id }} = {
-      {% for method_name, callsite in hsh %}{{method_name}}: {{callsite.id}},
+      {% for method_name, callsite in hsh %}{{method_name.stringify}}: {{callsite.id}},
       {% end %}}{% end %}
   end
 
@@ -175,8 +175,8 @@ module Send
         method_name = method.name
 
         safe_method_name = method_name
-        Xtn::SendMethodPunctuationLookups.each do |punct, name|
-          safe_method_name = safe_method_name.gsub(punct, name)
+        Xtn::SendMethodPunctuationLookups.each do |name, punct|
+          safe_method_name = safe_method_name.gsub(punct, name.stringify)
         end
       %}
       {% if use_procs == true %}


### PR DESCRIPTION
By making the constants NamedTuples, they get stored on the stack, and don't increase garbage collection load. This seems to make a small but perceptible difference in overall performance of the benchmark.